### PR TITLE
feat(ci): add production deployment workflow

### DIFF
--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -1,0 +1,209 @@
+name: Production deploy
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test-erp:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.PULL_KEY_REPO }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+          target: wasm32-unknown-unknown
+          toolchain: stable
+
+      - name: Install dependencies
+        run: sudo apt-get install -y libgtk-3-dev
+
+      - name: test
+        env:
+          RUSTFLAGS: "-A warnings"
+          DATABASE_TYPE: postgres
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
+        run: |
+          echo "" > packages/erp/public/tailwind.css
+          echo "" > packages/erp/public/dep.js
+          cd packages/erp && cargo test --tests --features web
+
+  test-api:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.PULL_KEY_REPO }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+          target: wasm32-unknown-unknown
+          toolchain: stable
+      - name: Install PostgreSQL Client
+        run: sudo apt-get install -y postgresql-client
+
+      - name: Initialize Database SQL
+        run: |
+          psql postgresql://postgres:postgres@localhost:5432/test -f ./deps/rust-sdk/fixtures/sql/init.sql
+
+      - name: test
+        env:
+          RUSTFLAGS: "-A warnings"
+          DATABASE_TYPE: postgres
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
+          ENV: "dev"
+          DOMAIN: "api.dev.biyard.co"
+          OPENAPI_KEY: ${{ secrets.OPENAPI_KEY }}
+          AUTH_SECRET_KEY: ${{ secrets.DEV_AUTH_SECRET_KEY }}
+          BASE_DOMAIN: "biyard.co"
+          AWS_REGION: ap-northeast-2
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.DEV_JWT_SECRET }}
+        run: |
+          cd packages/api  && cargo test --tests
+
+  erp:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.PULL_KEY_REPO }}
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+          target: wasm32-unknown-unknown
+          toolchain: stable
+
+      - uses: cargo-bins/cargo-binstall@main
+
+      - name: Install dioxus-cli
+        run: |
+          cargo binstall dioxus-cli --force
+          cargo binstall toml-cli --force
+
+      - name: Cache builder
+        id: main-ui-build-cache
+        uses: actions/cache@v3
+        with:
+          key: main-ui-build-cache
+          path: |
+            packages/main-ui/target
+
+      - name: Checking violate
+        env:
+          REGION: ap-northeast-2
+          ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SERVICE: erp
+        run: |
+          dx check -p $SERVICE
+
+      - name: Deploy UI
+        env:
+          REGION: ap-northeast-2
+          RUST_LOG: info
+          ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          FIREBASE_API_KEY: "${{ secrets.FIREBASE_API_KEY }}"
+          FIREBASE_AUTH_DOMAIN: "${{ secrets.FIREBASE_AUTH_DOMAIN }}"
+          FIREBASE_PROJECT_ID: "${{ secrets.FIREBASE_PROJECT_ID }}"
+          FIREBASE_STORAGE_BUCKET: "${{ secrets.FIREBASE_STORAGE_BUCKET }}"
+          FIREBASE_MESSAGING_SENDER_ID: "${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}"
+          FIREBASE_APP_ID: "${{ secrets.FIREBASE_APP_ID }}"
+          FIREBASE_MEASUREMENT_ID: "${{ secrets.FIREBASE_MEASUREMENT_ID }}"
+          MAIN_API_ENDPOINT: https://erp-api.biyard.co
+          RATEL_API_ENDPOINT: https://api.ratel.foundation
+          ENV: prod
+          SERVICE: erp
+          DOMAIN: erp.biyard.co
+          API_PREFIX: /api
+          ENABLE_S3: true
+          ENABLE_LAMBDA: true
+          VERSIONS: v1
+          V1_ENDPOINT: api.biyard.co
+        run: |
+          npm i -g aws-cdk @tailwindcss/cli
+          make deploy-web
+
+  api:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.PULL_KEY_REPO }}
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+          target: wasm32-unknown-unknown
+          toolchain: stable
+
+      - uses: cargo-bins/cargo-binstall@main
+      - name: Install toml-cli
+        run: |
+          cargo binstall toml-cli --force
+
+      - name: Deploy APIs
+        env:
+          REGION: ap-northeast-2
+          ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ENV: prod
+          RUST_LOG: info
+          SERVICE: api
+          DOMAIN: api.biyard.co
+          AUTH_DOMAIN: biyard.co
+          DATABASE_TYPE: postgres
+          RATEL_DATABASE_URL: ${{ secrets.RATEL_DATABASE_URL }}
+          AUTH_SECRET_KEY: ${{ secrets.AUTH_SECRET_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          ENABLE_S3: false
+          ENABLE_LAMBDA: true
+        run: |
+          npm i -g aws-cdk
+          make deploy


### PR DESCRIPTION
Add a new GitHub Actions workflow for production deployment. This workflow includes jobs for testing ERP and API, as well as deploying the ERP UI and APIs. The workflow is triggered on pushes to the main branch and sets up necessary environments and dependencies for the deployment process.